### PR TITLE
Add support code to let storage handlers be auto-closeable objects.

### DIFF
--- a/spinn_storage_handlers/abstract_classes/__init__.py
+++ b/spinn_storage_handlers/abstract_classes/__init__.py
@@ -1,0 +1,10 @@
+from .abstract_buffered_data_storage import AbstractBufferedDataStorage
+from .abstract_byte_reader import AbstractByteReader
+from .abstract_byte_writer import AbstractByteWriter
+from .abstract_context_manager import AbstractContextManager
+from .abstract_data_reader import AbstractDataReader
+from .abstract_data_writer import AbstractDataWriter
+
+__all__ = [
+    "AbstractBufferedDataStorage", "AbstractByteReader", "AbstractByteWriter",
+    "AbstractContextManager", "AbstractDataReader", "AbstractDataWriter" ]

--- a/spinn_storage_handlers/abstract_classes/__init__.py
+++ b/spinn_storage_handlers/abstract_classes/__init__.py
@@ -7,4 +7,5 @@ from .abstract_data_writer import AbstractDataWriter
 
 __all__ = [
     "AbstractBufferedDataStorage", "AbstractByteReader", "AbstractByteWriter",
-    "AbstractContextManager", "AbstractDataReader", "AbstractDataWriter" ]
+    "AbstractContextManager", "AbstractDataReader", "AbstractDataWriter"
+]

--- a/spinn_storage_handlers/abstract_classes/abstract_context_manager.py
+++ b/spinn_storage_handlers/abstract_classes/abstract_context_manager.py
@@ -1,0 +1,20 @@
+from six import add_metaclass
+
+from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+
+@add_metaclass(AbstractBase)
+class AbstractContextManager(object):
+    """Closeable class that supports being used as a simple context manager."""
+
+    __slots__ = []
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False

--- a/spinn_storage_handlers/abstract_classes/abstract_context_manager.py
+++ b/spinn_storage_handlers/abstract_classes/abstract_context_manager.py
@@ -2,6 +2,7 @@ from six import add_metaclass
 
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
+
 @add_metaclass(AbstractBase)
 class AbstractContextManager(object):
     """Closeable class that supports being used as a simple context manager."""

--- a/spinn_storage_handlers/buffered_bytearray_data_storage.py
+++ b/spinn_storage_handlers/buffered_bytearray_data_storage.py
@@ -1,11 +1,12 @@
 import os
-from spinn_storage_handlers.abstract_classes.abstract_buffered_data_storage \
-    import AbstractBufferedDataStorage
+from spinn_storage_handlers.abstract_classes \
+    import AbstractContextManager, AbstractBufferedDataStorage
 from spinn_storage_handlers.exceptions import \
     BufferedBytearrayOperationNotImplemented
 
 
-class BufferedBytearrayDataStorage(AbstractBufferedDataStorage):
+class BufferedBytearrayDataStorage(AbstractBufferedDataStorage,
+                                   AbstractContextManager):
     """Data storage based on a bytearray buffer with two pointers,
     one for reading and one for writing.
     """

--- a/spinn_storage_handlers/buffered_file_data_storage.py
+++ b/spinn_storage_handlers/buffered_file_data_storage.py
@@ -1,13 +1,14 @@
 import os
 from io import BlockingIOError
 
-from spinn_storage_handlers.abstract_classes.abstract_buffered_data_storage \
-    import AbstractBufferedDataStorage
+from spinn_storage_handlers.abstract_classes \
+    import AbstractBufferedDataStorage, AbstractContextManager
 from spinn_storage_handlers.exceptions import DataReadException, \
     DataWriteException
 
 
-class BufferedFileDataStorage(AbstractBufferedDataStorage):
+class BufferedFileDataStorage(AbstractBufferedDataStorage,
+                              AbstractContextManager):
     """Data storage based on a temporary file with two pointers, one for
     reading and one for writing.
     """

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -1,10 +1,11 @@
 import os
 import tempfile
-from spinn_storage_handlers.abstract_classes.abstract_buffered_data_storage \
-    import AbstractBufferedDataStorage
+from spinn_storage_handlers.abstract_classes \
+    import AbstractBufferedDataStorage, AbstractContextManager
 
 
-class BufferedTempfileDataStorage(AbstractBufferedDataStorage):
+class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
+                                  AbstractContextManager):
     """Data storage based on a temporary file with two pointers, one for
     reading and one for writing.
     """

--- a/spinn_storage_handlers/file_data_reader.py
+++ b/spinn_storage_handlers/file_data_reader.py
@@ -1,10 +1,10 @@
 from spinn_storage_handlers.buffered_file_data_storage import \
     BufferedFileDataStorage
-from spinn_storage_handlers.abstract_classes.abstract_data_reader import \
-    AbstractDataReader
+from spinn_storage_handlers.abstract_classes import \
+    AbstractDataReader, AbstractContextManager
 
 
-class FileDataReader(AbstractDataReader):
+class FileDataReader(AbstractDataReader, AbstractContextManager):
     """ A reader that can read data from a file
     """
 

--- a/spinn_storage_handlers/file_data_writer.py
+++ b/spinn_storage_handlers/file_data_writer.py
@@ -1,10 +1,10 @@
 from spinn_storage_handlers.buffered_file_data_storage import \
     BufferedFileDataStorage
-from spinn_storage_handlers.abstract_classes.abstract_data_writer import \
-    AbstractDataWriter
+from spinn_storage_handlers.abstract_classes import \
+    AbstractDataWriter, AbstractContextManager
 
 
-class FileDataWriter(AbstractDataWriter):
+class FileDataWriter(AbstractDataWriter, AbstractContextManager):
 
     __slots__ = [
         # the file container


### PR DESCRIPTION
This makes the concrete classes in SpiNNStorageHandlers into classes whose instances can be auto-closed when used in a `with` statement. That prevents the leaking of file handles.