### PR TITLE
Limit number of open file handles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+pylru >= 1
 six
 SpiNNUtilities >= 1!4.0.1, < 1!5.0.0

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(
     packages=packages,
     package_data=package_data,
     install_requires=['SpiNNUtilities >= 1!4.0.1, < 1!5.0.0',
-                      'six']
+                      'pylru >= 1', 'six']
 )

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -203,4 +203,4 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
             f.close()
 
 
-atexit.register(BufferedTempfileDataStorage._close_them_all)
+atexit.register(BufferedTempfileDataStorage.close_all)

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -12,7 +12,7 @@ _LRU_MAX = 100
 class _SimpleFileWrapper(object):
     def __init__(self, filename):
         global _LRU
-        self._file = open(filename, "w+b")
+        self._file = open(filename, "r+b")
         _LRU.append(self)
         if len(_LRU) > _LRU_MAX:
             trim, _LRU = _LRU[:len(_LRU)-_LRU_MAX], _LRU[-_LRU_MAX:]
@@ -45,13 +45,13 @@ class _SimpleFileWrapper(object):
         _LRU.append(self)
         return self._file.readinto(buffer)
 
-    def write(self, str):  # @ReservedAssignment
+    def write(self, buffer):  # @ReservedAssignment
         try:
             _LRU.remove(self)
         except ValueError:
             pass
         _LRU.append(self)
-        self._file.write(str)
+        self._file.write(buffer)
 
     def seek(self, a, b=None):
         if b is None:

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -90,7 +90,6 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
         f = tempfile.NamedTemporaryFile(delete=False)
         self._name = f.name
         f.close()
-        
         self._file = _SimpleFileWrapper(self._name)
         self._file_size = 0
         self._read_pointer = 0

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -106,7 +106,7 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
 
     def write(self, data):
         if not isinstance(data, bytearray):
-            raise
+            raise IOError("can only write bytearrays")
         f = self._handle
         f.seek(self._write_pointer)
         f.write(data)

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -1,7 +1,66 @@
+import atexit
 import os
 import tempfile
 from spinn_storage_handlers.abstract_classes \
     import AbstractBufferedDataStorage, AbstractContextManager
+
+
+_LRU = list()
+_LRU_MAX = 100
+
+
+class _SimpleFileWrapper(object):
+    def __init__(self, filename):
+        global _LRU
+        self._file = open(filename, "w+b")
+        _LRU.append(self)
+        if len(_LRU) > _LRU_MAX:
+            trim, _LRU = _LRU[:len(_LRU)-_LRU_MAX], _LRU[-_LRU_MAX:]
+            for f in trim:
+                f.close()
+
+    def close(self):
+        self._file.close()
+        try:
+            _LRU.remove(self)
+        except ValueError:
+            pass
+
+    def read(self, size=None):
+        try:
+            _LRU.remove(self)
+        except ValueError:
+            pass
+        _LRU.append(self)
+        if size is None:
+            return self._file.read()
+        else:
+            return self._file.read(size)
+
+    def readinto(self, buffer):  # @ReservedAssignment
+        try:
+            _LRU.remove(self)
+        except ValueError:
+            pass
+        _LRU.append(self)
+        return self._file.readinto(buffer)
+
+    def write(self, str):  # @ReservedAssignment
+        try:
+            _LRU.remove(self)
+        except ValueError:
+            pass
+        _LRU.append(self)
+        self._file.write(str)
+
+    def seek(self, a, b=None):
+        if b is None:
+            self._file.seek(a)
+        else:
+            self._file.seek(a, b)
+
+    def tell(self):
+        return self._file.tell()
 
 
 class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
@@ -21,36 +80,52 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
         "_write_pointer",
 
         # ?????????
-        "_file"
+        "_file",
+        "_name"
     ]
 
+    _ALL = list()
+
     def __init__(self):
-        self._file = tempfile.TemporaryFile()
+        f = tempfile.NamedTemporaryFile(delete=False)
+        self._name = f.name
+        f.close()
+        
+        self._file = _SimpleFileWrapper(self._name)
         self._file_size = 0
         self._read_pointer = 0
         self._write_pointer = 0
+        BufferedTempfileDataStorage._ALL.append(self)
 
     def write(self, data):
         if not isinstance(data, bytearray):
             raise
+        if self._file not in _LRU:
+            self._file = _SimpleFileWrapper(self._name)
         self._file.seek(self._write_pointer)
         self._file.write(data)
         self._file_size += len(data)
         self._write_pointer += len(data)
 
     def read(self, data_size):
+        if self._file not in _LRU:
+            self._file = _SimpleFileWrapper(self._name)
         self._file.seek(self._read_pointer)
         data = self._file.read(data_size)
         self._read_pointer += data_size
         return bytearray(data)
 
     def readinto(self, data):
+        if self._file not in _LRU:
+            self._file = _SimpleFileWrapper(self._name)
         self._file.seek(self._read_pointer)
         data_size = self._file.readinto(data)
         self._read_pointer += data_size
         return data_size
 
     def read_all(self):
+        if self._file not in _LRU:
+            self._file = _SimpleFileWrapper(self._name)
         self._file.seek(0)
         data = self._file.read()
         self._read_pointer = self._file.tell()
@@ -97,7 +172,10 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
         return (file_len - self._read_pointer) <= 0
 
     def close(self):
-        self._file.close()
+        if self._file in _LRU:
+            self._file.close()
+        BufferedTempfileDataStorage._ALL.remove(self)
+        os.unlink(self._name)
 
     @property
     def _file_len(self):
@@ -106,8 +184,20 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
         :return: The size of the file
         :rtype: int
         """
+        if self._file not in _LRU:
+            self._file = _SimpleFileWrapper(self._name)
         current_pos = self._file.tell()
         self._file.seek(0, 2)
         end_pos = self._file.tell()
         self._file.seek(current_pos)
         return end_pos
+
+    @staticmethod
+    def close_all():
+        # Copy!
+        alltoclose = list(BufferedTempfileDataStorage._ALL)
+        for f in alltoclose:
+            f.close()
+
+
+atexit.register(BufferedTempfileDataStorage._close_them_all)

--- a/tests/test_file_data.py
+++ b/tests/test_file_data.py
@@ -17,7 +17,7 @@ def temp_dir(tmpdir):
     # Cleanup
     try:
         thedir.remove(ignore_errors=True)
-    except:
+    except Exception:
         pass
     assert thedir.check(exists=0)
 

--- a/tests/test_tempfile_data.py
+++ b/tests/test_tempfile_data.py
@@ -3,6 +3,7 @@ from spinn_storage_handlers import BufferedTempfileDataStorage
 
 
 testdata = bytearray("ABcd1234")
+MANY_TEMP_FILES = 2000
 
 
 def test_readwrite_tempfile_buffer(tmpdir):
@@ -13,3 +14,17 @@ def test_readwrite_tempfile_buffer(tmpdir):
     assert btds._file_len == len(testdata)
     assert btds.read_all() == testdata
     btds.close()
+
+
+def test_lots_of_tempfiles():
+    temps = list()
+    for i in xrange(MANY_TEMP_FILES):
+        b = BufferedTempfileDataStorage()
+        b.write(str(i))
+        temps.append(b)
+    vals = list()
+    for t in temps:
+        vals.append(int(t.read()))
+    assert vals == sorted(list(vals))
+    for t in temps:
+        t.close()

--- a/tests/test_tempfile_data.py
+++ b/tests/test_tempfile_data.py
@@ -1,5 +1,6 @@
 # import py.test
 from spinn_storage_handlers import BufferedTempfileDataStorage
+import os
 
 
 testdata = bytearray("ABcd1234")
@@ -20,11 +21,20 @@ def test_lots_of_tempfiles():
     temps = list()
     for i in xrange(MANY_TEMP_FILES):
         b = BufferedTempfileDataStorage()
-        b.write(str(i))
+        assert b not in temps
         temps.append(b)
+        s = str(i)
+        assert len(s) > 0
+        b.write(bytearray(s))
+        assert b._write_pointer > 0
+    assert len(temps) == MANY_TEMP_FILES
     vals = list()
     for t in temps:
-        vals.append(int(t.read()))
+        vals.append(int(t.read_all()))
+        assert t._read_pointer != 0
     assert vals == sorted(list(vals))
     for t in temps:
+        flnm = t._name
+        assert os.path.isfile(flnm)
         t.close()
+        assert not os.path.isfile(flnm)


### PR DESCRIPTION
This adds a least-recently-used cache management system to the internals of `BufferedTempfileDataStorage` so that having very large numbers of temporary files open at once (e.g., 2000 in the new test case) doesn't result in a vast number of system file handles being used. They should be otherwise functionally identical to the old (public) API.