### PR TITLE
Minor fixes

### DIFF
--- a/spinn_storage_handlers/abstract_classes/abstract_buffered_data_storage.py
+++ b/spinn_storage_handlers/abstract_classes/abstract_buffered_data_storage.py
@@ -1,12 +1,9 @@
 # general imports
+import os
+import logging
 from six import add_metaclass
 
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
-
-
-import os
-import logging
-
 
 logger = logging.getLogger(__name__)
 

--- a/spinn_storage_handlers/abstract_classes/abstract_byte_reader.py
+++ b/spinn_storage_handlers/abstract_classes/abstract_byte_reader.py
@@ -21,8 +21,8 @@ class AbstractByteReader(object):
         """ Indicates whether the reader is currently at the end of the byte\
             reader.
 
-        :return: true if the reader is currently at the end of the byte\
-            reader, false otherwise.
+        :return: whether the reader is currently at the end of the byte\
+            reader.
         :rtype: bool
         """
 

--- a/spinn_storage_handlers/buffered_tempfile_data_storage.py
+++ b/spinn_storage_handlers/buffered_tempfile_data_storage.py
@@ -66,7 +66,7 @@ class BufferedTempfileDataStorage(AbstractBufferedDataStorage,
 
     @overrides(AbstractBufferedDataStorage.write)
     def write(self, data):
-        if not isinstance(data, bytearray):
+        if not isinstance(data, (bytes, bytearray)):
             raise IOError("can only write bytearrays")
         f = self._handle
         f.seek(self._write_pointer)

--- a/tests/test_tempfile_data.py
+++ b/tests/test_tempfile_data.py
@@ -1,6 +1,7 @@
 from spinn_storage_handlers import BufferedTempfileDataStorage
 import os
 import pytest
+import six
 
 testdata = bytearray(b"ABcd1234")
 MANY_TEMP_FILES = 2000
@@ -44,8 +45,8 @@ def test_lots_of_tempfiles():
 def test_basic_ops():
     with BufferedTempfileDataStorage() as f:
         with pytest.raises(IOError):
-            f.write(b"abcde")
-        f.write(bytearray(b"abcde"))
+            f.write(six.text_type("abcde"))
+        f.write(b"abcde")
         f.seek_write(3)
         f.write(bytearray(b"ba"))
         f.seek_read(1)


### PR DESCRIPTION
Fixes to docs, accepted types for one method, and ordering of imports. (It's generally supposed to be best to import system libs first; there are lint rules for it even though we usually ignore them.)